### PR TITLE
Fix crash when fake player dig slade

### DIFF
--- a/df_underworld_items/slade.lua
+++ b/df_underworld_items/slade.lua
@@ -3,7 +3,7 @@ local S = minetest.get_translator(minetest.get_current_modname())
 local invulnerable = df_underworld_items.config.invulnerable_slade and not minetest.settings:get_bool("creative_mode")
 
 local server_diggable_only = function(pos, player)
-	if player then
+	if player and player:is_player() then
 		return minetest.check_player_privs(player, "server")
 	end
 	return false


### PR DESCRIPTION
When a fake player, for example a node, dig slade, it return `player ~= nil` but it is not a current player, the `server_diggable_only` function tries to check the privs of the node, then this crashes

Here we use the built-in check `player:is_player()` so the node privs are not checked

This crash occurs, for example, in the [technic mod when the corium eats the slade](https://github.com/mt-mods/technic/pull/328/commits/2b39f6a8622c8d46c8d33dcd56c88c889bc3f08b)

And can occur in any other mod that uses fake players