### PR TITLE
Fix bedrock in mineclone2

### DIFF
--- a/df_dependencies/mapgen.lua
+++ b/df_dependencies/mapgen.lua
@@ -215,8 +215,11 @@ if minetest.get_modpath("mcl_init") then -- Mineclone 2
 	
 	mcl_vars.mg_overworld_min = lowest_elevation
 	mcl_vars.mg_bedrock_overworld_min = mcl_vars.mg_overworld_min
+	mcl_vars.mg_bedrock_overworld_max = mcl_vars.mg_overworld_min + 4
 	mcl_vars.mg_lava_overworld_max = mcl_vars.mg_overworld_min + 10
 	mcl_vars.mg_end_max = mcl_vars.mg_overworld_min - 2000
+	mcl_vars.mg_realm_barrier_overworld_end_max = mcl_vars.mg_end_max
+	mcl_vars.mg_realm_barrier_overworld_end_min = mcl_vars.mg_end_max - 11
 
 	-- shouldn't need to worry about the setting, extend_ores checks if the ores
 	-- have already been registered.

--- a/df_dependencies/mapgen.lua
+++ b/df_dependencies/mapgen.lua
@@ -221,6 +221,28 @@ if minetest.get_modpath("mcl_init") then -- Mineclone 2
 	mcl_vars.mg_realm_barrier_overworld_end_max = mcl_vars.mg_end_max
 	mcl_vars.mg_realm_barrier_overworld_end_min = mcl_vars.mg_end_max - 11
 
+	-- try to detect any variables that should have been modified but weren't
+	local bad_entries = {}
+	for k, v in pairs(mcl_vars) do
+		-- if a value is in this range, it's probably a new value added by MineClone2 that we should be adjusting, add it to the table
+		if type(v) == "number" and v <= old_overworld_min + 10 and v >= mcl_vars.mg_overworld_min + 100 then
+			bad_entries[k] = v
+		end
+	end
+
+	-- mark variables as ignored that we intentionally don't change, like so:
+	-- bad_entries.mg_value_that_shouldnt_be_adjusted = nil
+
+	for k, v in pairs(bad_entries) do
+		local new_value = v + mcl_vars.mg_overworld_min - old_overworld_min
+		minetest.log("error", "dfcaverns: variable wasn't modified or marked as ignored! guessing new value:")
+		minetest.log("error", "mcl_var." .. tostring(k) .. " = " .. tostring(new_value) .. " -- was " .. tostring(v))
+		minetest.log("error", "if it shouldn't be changed, mark it as ignored in df_dependencies/mapgen.lua like so:")
+		minetest.log("error", "bad_entries." .. tostring(k) .. " = nil")
+		minetest.log("error", "This is a bug, please report it to https://github.com/FaceDeer/dfcaverns/issues/new")
+		mcl_vars[k] = new_value
+	end
+
 	-- shouldn't need to worry about the setting, extend_ores checks if the ores
 	-- have already been registered.
 	--if minetest.settings:get_bool("mcl_generate_ores", true) then


### PR DESCRIPTION
This changes additional mcl_vars variables that were added to MineClone2, as well as adding some code to try to detect if there's any new variables added in the future that should also be changed.

If it finds any, it changes the new variables to guessed values and logs an error message saying to report a bug and how to mark the variable as ignored because we decided to intentionally not change it.

Fixes: #48
Fixes: https://git.minetest.land/MineClone2/MineClone2/issues/4016